### PR TITLE
Include solve for mono installation error on M1/M2 Arm64 architecture in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,8 @@ Pythonnet will be automatically installed via pip.
 
 1.  Install [brew](https://brew.sh).
 2.  Install mono: `brew install mono`.
-3.  Create a pseudo mono folder: `sudo mkdir -p /Library/Frameworks/Mono.framework/Versions`.
-4.  Link homebrew mono to pseudo mono folder: `sudo ln -s /opt/homebrew/Cellar/mono/6.12.0.182 /Library/Frameworks/Mono.framework/Versions`. Here, `6.12.0.182` is the brew-installed mono version, please check your installed version. Navigate to `/Library/Frameworks/Mono.framework/Versions` and run `ls -l` to verify that the link `Current` points to `/opt/homebrew/Cellar/mono/6.12.0.182`. If `Current` points to a different installation and/or `/opt/homebrew/Cellar/mono/6.12.0.182` is referenced by a different link, delete the corresponding links and run `ln -s /opt/homebrew/Cellar/mono/6.12.0.182 Current`.     
+3.  If the pseudo mono folder `/Library/Frameworks/Mono.framework/Versions` does not exist, create it by running `sudo mkdir -p /Library/Frameworks/Mono.framework/Versions`.
+4.  Link homebrew mono to pseudo mono folder: `sudo ln -s /opt/homebrew/Cellar/mono/6.12.0.182 /Library/Frameworks/Mono.framework/Versions/Current`. Here, `6.12.0.182` is the brew-installed mono version, please check your installed version. Navigate to `/Library/Frameworks/Mono.framework/Versions` and run `ls -l` to verify that the link `Current` points to `/opt/homebrew/Cellar/mono/6.12.0.182`. If `Current` points to a different installation and/or `/opt/homebrew/Cellar/mono/6.12.0.182` is referenced by a different link, delete the corresponding links and run `sudo ln -s /opt/homebrew/Cellar/mono/6.12.0.182 Current`.     
 5.  Install pythonnet: `pip install pythonnet`.
 
 ------------------------------------------------------------------------


### PR DESCRIPTION
If the "Current" link in /Library/Frameworks/Mono.framework/Versions does not point to the brew installation of mono, importing the Thermo Rawfile Reader fails. This fixes the issue by setting "Current" to point to the correct installation of mono.