### PR TITLE
Bump version: 0.4.4 → 0.4.5

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.4.4
+current_version = 0.4.5
 commit = True
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+)(?P<build>\d+))?

--- a/alpharaw/__init__.py
+++ b/alpharaw/__init__.py
@@ -15,7 +15,7 @@ def register_readers():
         print("[WARN] pythonnet is not installed")
 
 __project__ = "alpharaw"
-__version__ = "0.4.4"
+__version__ = "0.4.5"
 __license__ = "Apache"
 __description__ = "An open-source Python package to unify raw MS data access and storage."
 __author__ = "Mann Labs"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -23,7 +23,7 @@ project = 'alpharaw'
 copyright = '2022, Mann Labs, MPIB'
 author = 'Mann Labs, MPIB'
 
-release = "0.4.4"
+release = "0.4.5"
 
 # -- General configuration ---------------------------------------------------
 


### PR DESCRIPTION
Due to failed pypi release, we need a new version number