### PR TITLE
53 docs init pattern

### DIFF
--- a/alpharaw/ms_data_base.py
+++ b/alpharaw/ms_data_base.py
@@ -73,7 +73,7 @@ class MSData_Base:
         Parameters
         ----------
         centroided : bool, optional
-            If centroiding the peak data, by default True
+            If peaks will be centroided after loading, by default True
         save_as_hdf : bool, optional
             If automatically save the data into HDF5 format, by default False
         """
@@ -479,7 +479,7 @@ class MSReaderProvider:
         ms_file_type : str
             AlphaRaw supported MS file types.
         centroided : bool, optional
-            If centroiding the data, by default True.
+            If peaks will be centroided after loading, by default True.
 
         Returns
         -------

--- a/alpharaw/ms_data_base.py
+++ b/alpharaw/ms_data_base.py
@@ -7,13 +7,6 @@ from alphabase.io.hdf import HDF_File
 class MSData_Base:
     """
     The base data structure for MS RAW Data, other MSData loaders inherit this class.
-
-    Parameters
-    ----------
-    centroided : bool, optional
-        If centroiding the peak data, by default True
-    save_as_hdf : bool, optional
-        If automatically save the data into HDF5 format, by default False
     """
 
     column_dtypes = {
@@ -76,6 +69,14 @@ class MSData_Base:
     """
 
     def __init__(self, centroided: bool = True, save_as_hdf: bool = False, **kwargs):
+        """
+        Parameters
+        ----------
+        centroided : bool, optional
+            If centroiding the peak data, by default True
+        save_as_hdf : bool, optional
+            If automatically save the data into HDF5 format, by default False
+        """
         # A spectrum contains peaks
         self.spectrum_df: pd.DataFrame = pd.DataFrame()
         # A peak contains mz, intensity, and ...

--- a/alpharaw/thermo.py
+++ b/alpharaw/thermo.py
@@ -54,22 +54,6 @@ class ThermoRawData(MSData_Base):
     Loading Thermo Raw data as MSData_Base data structure.
     This class is registered "thermo" and "thermo_raw" in
     :obj:`alpharaw.ms_data_base.ms_reader_provider`.
-
-    Parameters
-    ----------
-    centroided : bool, optional
-        If peaks will be centroided after loading. By defaults True.
-    process_count : int, optional
-        Number of processes to load RAW data, by default 10.
-    mp_batch_size : int, optional
-        Number of spectra to load in each batch, by default 5000.
-    save_as_hdf : bool, optional
-        Automatically save hdf after load raw data, by default False.
-    dda : bool, optional
-        Is DDA data, by default False.
-    auxiliary_items : list, optional
-        Additional spectrum items, candidates are in :data:`auxiliary_item_dtypes`.
-        By default [].
     """
 
     def __init__(
@@ -82,6 +66,23 @@ class ThermoRawData(MSData_Base):
         auxiliary_items: list = [],
         **kwargs,
     ):
+        """
+        Parameters
+        ----------
+        centroided : bool, optional
+            If peaks will be centroided after loading. By defaults True.
+        process_count : int, optional
+            Number of processes to load RAW data, by default 10.
+        mp_batch_size : int, optional
+            Number of spectra to load in each batch, by default 5000.
+        save_as_hdf : bool, optional
+            Automatically save hdf after load raw data, by default False.
+        dda : bool, optional
+            Is DDA data, by default False.
+        auxiliary_items : list, optional
+            Additional spectrum items, candidates are in :data:`auxiliary_item_dtypes`.
+            By default [].
+        """
         super().__init__(centroided, save_as_hdf=save_as_hdf, **kwargs)
         self.file_type = "thermo"
         self.process_count = process_count

--- a/alpharaw/wrappers/alphatims_wrapper.py
+++ b/alpharaw/wrappers/alphatims_wrapper.py
@@ -8,7 +8,7 @@ from ..ms_data_base import MSData_Base
 
 class AlphaTimsReader(MSData_Base):
     """
-    > TimsTOF data are too large, do not use this class
+    TimsTOF data are too large, do not use this class
     """
 
     def import_raw(self, burker_d_folder: str):
@@ -43,8 +43,16 @@ class AlphaTimsReader(MSData_Base):
 
 
 class AlphaTimsWrapper(TimsTOF):
-    """Create a AlphaTims object that contains
+    """Create a AlphaTims object containing
     all data in-memory (or memory mapping).
+
+    Attribute
+    ---------
+    slice_as_dataframe
+        Attribute from AlphaTims.
+        If True, AlphaTims slicing returns a pd.DataFrame by default.
+        If False, AlphaTims slicing provides a np.int64[:] with raw indices.
+        The value can be modified on-the-fly.
     """
 
     def __init__(self, msdata: MSData_Base, dda: bool, slice_as_dataframe: bool = True):
@@ -62,14 +70,15 @@ class AlphaTimsWrapper(TimsTOF):
         slice_as_dataframe : bool
             If True, slicing returns a pd.DataFrame by default.
             If False, slicing provides a np.int64[:] with raw indices.
-            This value can also be modified after creation.
             Default is True.
         """
         self._use_calibrated_mz_values_as_default = False
         self._import_alpharaw_object(msdata, dda)
         self.thermo_raw_file_name = msdata.raw_file_path
         self.bruker_d_folder_name = self.thermo_raw_file_name
-        self.slice_as_dataframe = slice_as_dataframe
+        self.slice_as_dataframe = (
+            slice_as_dataframe  # This value can be modified after creation.
+        )
         # Precompile
         self[0, "raw"]
 

--- a/alpharaw/wrappers/alphatims_wrapper.py
+++ b/alpharaw/wrappers/alphatims_wrapper.py
@@ -45,25 +45,26 @@ class AlphaTimsReader(MSData_Base):
 class AlphaTimsWrapper(TimsTOF):
     """Create a AlphaTims object that contains
     all data in-memory (or memory mapping).
-
-    Parameters
-    ----------
-    msdata : MSData_Base
-        The AlphaRaw data object.
-
-    dda : bool
-        If DDA, precursor indices will be equal to scan numbers.
-        If not DDA (i.e. DIA), precursor indices will be equal to the
-        scan number within a DIA cycle.
-
-    slice_as_dataframe : bool
-        If True, slicing returns a pd.DataFrame by default.
-        If False, slicing provides a np.int64[:] with raw indices.
-        This value can also be modified after creation.
-        Default is True.
     """
 
     def __init__(self, msdata: MSData_Base, dda: bool, slice_as_dataframe: bool = True):
+        """
+        Parameters
+        ----------
+        msdata : MSData_Base
+            The AlphaRaw data object.
+
+        dda : bool
+            If DDA, precursor indices will be equal to scan numbers.
+            If not DDA (i.e. DIA), precursor indices will be equal to the
+            scan number within a DIA cycle.
+
+        slice_as_dataframe : bool
+            If True, slicing returns a pd.DataFrame by default.
+            If False, slicing provides a np.int64[:] with raw indices.
+            This value can also be modified after creation.
+            Default is True.
+        """
         self._use_calibrated_mz_values_as_default = False
         self._import_alpharaw_object(msdata, dda)
         self.thermo_raw_file_name = msdata.raw_file_path


### PR DESCRIPTION
For a class, move init params into __init__ method,  instead of the class definition.