### PR TITLE
Filter unused fragments from peak_df

### DIFF
--- a/alpharaw/ms_data_base.py
+++ b/alpharaw/ms_data_base.py
@@ -1,7 +1,64 @@
 import numpy as np
 import pandas as pd
+import numba
+import copy
 from alphabase.constants._const import PEAK_INTENSITY_DTYPE, PEAK_MZ_DTYPE
 from alphabase.io.hdf import HDF_File
+
+
+@numba.njit
+def get_peaks_to_keep_mask(
+    peak_count, peak_start_indices, peak_stop_indices, spec_mask
+) -> tuple:
+    """
+    Generate a mask for peaks to keep and reindex spectrum indices
+    
+    Parameters
+    ----------
+    peak_count : int
+        Total number of peaks in the dataset
+    peak_start_indices : np.ndarray
+        Array of peak start indices for each spectrum
+    peak_stop_indices : np.ndarray
+        Array of peak stop indices for each spectrum
+    spec_mask : np.ndarray
+        Boolean mask indicating which spectra to keep
+        
+    Returns
+    -------
+    tuple
+        (peaks_mask, new_start_indices, new_stop_indices)
+        - peaks_mask: boolean mask with True for peaks to keep
+        - new_start_indices: reindexed start indices for each kept spectrum
+        - new_stop_indices: reindexed stop indices for each kept spectrum
+    """
+    # Create a mask for peaks to keep
+    peaks_mask = np.zeros(peak_count, dtype=np.bool_)
+    
+    # Get filtered spectrum indices
+    kept_spec_indices = np.nonzero(spec_mask)[0]
+    
+    # Mark peaks to keep
+    for spec_idx in kept_spec_indices:
+        start, stop = peak_start_indices[spec_idx], peak_stop_indices[spec_idx]
+        peaks_mask[start:stop] = True
+    
+    # Create new peak indices
+    new_start_indices = np.empty(len(kept_spec_indices), dtype=np.int64)
+    new_stop_indices = np.empty(len(kept_spec_indices), dtype=np.int64)
+    
+    # Calculate cumulative sums for new indices
+    peak_cumsum = np.zeros(peak_count + 1, dtype=np.int64)
+    for i in range(peak_count):
+        peak_cumsum[i+1] = peak_cumsum[i] + (1 if peaks_mask[i] else 0)
+    
+    # Assign new indices
+    for i, spec_idx in enumerate(kept_spec_indices):
+        start, stop = peak_start_indices[spec_idx], peak_stop_indices[spec_idx]
+        new_start_indices[i] = peak_cumsum[start]
+        new_stop_indices[i] = peak_cumsum[stop]
+    
+    return peaks_mask, new_start_indices, new_stop_indices
 
 
 class MSData_Base:
@@ -419,6 +476,55 @@ class MSData_Base:
         self.peak_df.intensity.values[:] = np.concatenate(intens_list)
         self.spectrum_df["peak_start_idx"] = peak_indices[:-1]
         self.spectrum_df["peak_stop_idx"] = peak_indices[1:]
+        
+    def remove_unused_peaks(self, in_place=True):
+        """
+        Remove unused peaks from peak_df and reindex the peak indices in spectrum_df.
+        
+        Assumes that spectra have already been removed from spectrum_df.
+        This method will rebuild the peak_df to contain only referenced peaks.
+        Preserves all columns in both peak_df and spectrum_df.
+        
+        Parameters
+        ----------
+        in_place : bool
+            If True, modify this object. If False, return a new instance.
+        
+        Returns
+        -------
+        MSData_Base or None
+            New instance if in_place=False, None otherwise.
+        """
+        # Create mask for all spectra (assume we want to keep all current spectra)
+        spec_mask = np.ones(len(self.spectrum_df), dtype=bool)
+        
+        # Generate mask for peaks to keep and get new indices
+        peaks_mask, new_start_indices, new_stop_indices = get_peaks_to_keep_mask(
+            len(self.peak_df), 
+            self.spectrum_df.peak_start_idx.values, 
+            self.spectrum_df.peak_stop_idx.values,
+            spec_mask
+        )
+        
+        # Create a new filtered peak dataframe
+        new_peak_df = self.peak_df[peaks_mask].reset_index(drop=True)
+        
+        if in_place:
+            # Update in place
+            self.peak_df = new_peak_df
+            self.spectrum_df["peak_start_idx"] = new_start_indices
+            self.spectrum_df["peak_stop_idx"] = new_stop_indices
+            return None
+        else:
+            # Create a deep copy of the current instance
+            new_instance = copy.deepcopy(self)
+            
+            # Update dataframes with new values
+            new_instance.peak_df = new_peak_df
+            new_instance.spectrum_df = self.spectrum_df.copy()
+            new_instance.spectrum_df["peak_start_idx"] = new_start_indices
+            new_instance.spectrum_df["peak_stop_idx"] = new_stop_indices
+            return new_instance
 
 
 def index_ragged_list(ragged_list: list) -> np.ndarray:

--- a/alpharaw/ms_data_base.py
+++ b/alpharaw/ms_data_base.py
@@ -1,5 +1,3 @@
-import copy
-
 import numba
 import numpy as np
 import pandas as pd
@@ -472,7 +470,7 @@ class MSData_Base:
         self.spectrum_df["peak_start_idx"] = peak_indices[:-1]
         self.spectrum_df["peak_stop_idx"] = peak_indices[1:]
 
-    def remove_unused_peaks(self, in_place=True):
+    def remove_unused_peaks(self):
         """
 
         If the spectrum_df object is filtered, the spectra are not removed from the peak_df.
@@ -481,11 +479,6 @@ class MSData_Base:
         Assumes that spectra have already been removed from spectrum_df.
         This method will rebuild the peak_df to contain only referenced peaks.
         Preserves all columns in both peak_df and spectrum_df.
-
-        Parameters
-        ----------
-        in_place : bool
-            If True, modify this object. If False, return a new instance.
 
         Returns
         -------
@@ -502,18 +495,10 @@ class MSData_Base:
 
         new_peak_df = self.peak_df[peaks_mask].reset_index(drop=True)
 
-        if in_place:
-            self.peak_df = new_peak_df
-            self.spectrum_df["peak_start_idx"] = new_start_indices
-            self.spectrum_df["peak_stop_idx"] = new_stop_indices
-            return None
-        else:
-            new_instance = copy.deepcopy(self)
-
-            new_instance.peak_df = new_peak_df
-            new_instance.spectrum_df["peak_start_idx"] = new_start_indices
-            new_instance.spectrum_df["peak_stop_idx"] = new_stop_indices
-            return new_instance
+        self.peak_df = new_peak_df
+        self.spectrum_df["peak_start_idx"] = new_start_indices
+        self.spectrum_df["peak_stop_idx"] = new_stop_indices
+        return None
 
 
 def index_ragged_list(ragged_list: list) -> np.ndarray:

--- a/tests/unit/test_remove_unused_peaks.py
+++ b/tests/unit/test_remove_unused_peaks.py
@@ -1,0 +1,192 @@
+import numpy as np
+import pandas as pd
+import pytest
+from alpharaw.ms_data_base import MSData_Base
+
+
+# Define a custom subclass for testing
+class CustomMSData(MSData_Base):
+    """A custom subclass of MSData_Base for testing inheritance behavior"""
+    
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.custom_attribute = "custom_value"
+        self.another_attribute = 42
+
+
+def test_remove_unused_peaks_basic():
+    """Test the basic functionality of remove_unused_peaks"""
+    # Create a simple MSData_Base instance
+    ms_data = MSData_Base()
+    
+    # Create spectrum_df with 3 spectra
+    ms_data.spectrum_df = pd.DataFrame({
+        "spec_idx": [0, 1, 2],
+        "rt": [1.0, 2.0, 3.0],
+        "ms_level": [1, 2, 2],
+        "peak_start_idx": [0, 5, 10],
+        "peak_stop_idx": [5, 10, 15]
+    })
+    
+    # Create peak_df with 15 peaks (5 per spectrum)
+    ms_data.peak_df = pd.DataFrame({
+        "mz": np.arange(15, dtype=np.float32) + 100,
+        "intensity": np.arange(15, dtype=np.float32) * 1000
+    })
+    
+    # Test in-place modification
+    result = ms_data.remove_unused_peaks(in_place=True)
+    
+    # Verify that the method returns None for in-place modification
+    assert result is None
+    
+    # Verify that the peak indices remain the same since no spectra were removed
+    assert len(ms_data.peak_df) == 15
+    assert np.array_equal(ms_data.spectrum_df["peak_start_idx"].values, [0, 5, 10])
+    assert np.array_equal(ms_data.spectrum_df["peak_stop_idx"].values, [5, 10, 15])
+
+
+def test_remove_unused_peaks_with_filtering():
+    """Test remove_unused_peaks when spectra have been removed"""
+    # Create a simple MSData_Base instance
+    ms_data = MSData_Base()
+    
+    # Create spectrum_df with 3 spectra initially
+    ms_data.spectrum_df = pd.DataFrame({
+        "spec_idx": [0, 1, 2],
+        "rt": [1.0, 2.0, 3.0],
+        "ms_level": [1, 2, 2],
+        "peak_start_idx": [0, 5, 10],
+        "peak_stop_idx": [5, 10, 15]
+    })
+    
+    # Create peak_df with 15 peaks (5 per spectrum)
+    ms_data.peak_df = pd.DataFrame({
+        "mz": np.arange(15, dtype=np.float32) + 100,
+        "intensity": np.arange(15, dtype=np.float32) * 1000
+    })
+    
+    # Filter out the middle spectrum (index 1)
+    ms_data.spectrum_df = ms_data.spectrum_df.loc[[0, 2]].reset_index(drop=True)
+    ms_data.spectrum_df["spec_idx"] = ms_data.spectrum_df.index
+    
+    # Now call remove_unused_peaks with in_place=False to get a new instance
+    new_ms_data = ms_data.remove_unused_peaks(in_place=False)
+    
+    # Verify that the original instance is unchanged
+    assert len(ms_data.peak_df) == 15
+    assert np.array_equal(ms_data.spectrum_df["peak_start_idx"].values, [0, 10])
+    assert np.array_equal(ms_data.spectrum_df["peak_stop_idx"].values, [5, 15])
+    
+    # Verify that the new instance has the correct peak data
+    assert len(new_ms_data.peak_df) == 10  # 5 peaks for spec 0 and 5 for spec 2
+    assert np.array_equal(new_ms_data.spectrum_df["peak_start_idx"].values, [0, 5])
+    assert np.array_equal(new_ms_data.spectrum_df["peak_stop_idx"].values, [5, 10])
+    
+    # Verify that the peak values are correct
+    expected_mzs = np.concatenate([
+        np.arange(5, dtype=np.float32) + 100,  # First 5 peaks from spec 0
+        np.arange(5, dtype=np.float32) + 110   # Last 5 peaks from spec 2
+    ])
+    expected_intensities = np.concatenate([
+        np.arange(5, dtype=np.float32) * 1000,  # First 5 peaks from spec 0
+        np.arange(10, 15, dtype=np.float32) * 1000  # Last 5 peaks from spec 2
+    ])
+    
+    assert np.array_equal(new_ms_data.peak_df["mz"].values, expected_mzs)
+    assert np.array_equal(new_ms_data.peak_df["intensity"].values, expected_intensities)
+
+
+def test_remove_unused_peaks_with_extra_columns():
+    """Test remove_unused_peaks preserves additional columns in peak_df"""
+    # Create a simple MSData_Base instance
+    ms_data = MSData_Base()
+    
+    # Create spectrum_df with 3 spectra
+    ms_data.spectrum_df = pd.DataFrame({
+        "spec_idx": [0, 1, 2],
+        "rt": [1.0, 2.0, 3.0],
+        "ms_level": [1, 2, 2],
+        "peak_start_idx": [0, 5, 10],
+        "peak_stop_idx": [5, 10, 15],
+        "extra_spec_col": ["a", "b", "c"]  # Extra column in spectrum_df
+    })
+    
+    # Create peak_df with 15 peaks and an extra column
+    ms_data.peak_df = pd.DataFrame({
+        "mz": np.arange(15, dtype=np.float32) + 100,
+        "intensity": np.arange(15, dtype=np.float32) * 1000,
+        "extra_peak_col": np.arange(15, dtype=np.float32) * 0.1,  # Extra column in peak_df
+        "extra_str_col": [f"peak_{i}" for i in range(15)]  # String column
+    })
+    
+    # Filter out the middle spectrum (index 1)
+    ms_data.spectrum_df = ms_data.spectrum_df.loc[[0, 2]].reset_index(drop=True)
+    ms_data.spectrum_df["spec_idx"] = ms_data.spectrum_df.index
+    
+    # Call remove_unused_peaks with in_place=True
+    ms_data.remove_unused_peaks(in_place=True)
+    
+    # Verify that the peak data is correct
+    assert len(ms_data.peak_df) == 10  # 5 peaks for spec 0 and 5 for spec 2
+    assert np.array_equal(ms_data.spectrum_df["peak_start_idx"].values, [0, 5])
+    assert np.array_equal(ms_data.spectrum_df["peak_stop_idx"].values, [5, 10])
+    
+    # Verify that extra columns are preserved
+    assert "extra_peak_col" in ms_data.peak_df.columns
+    assert "extra_str_col" in ms_data.peak_df.columns
+    assert "extra_spec_col" in ms_data.spectrum_df.columns
+    
+    # Verify that the extra column values are correctly mapped
+    expected_extra_peak_col = np.concatenate([
+        np.arange(5, dtype=np.float32) * 0.1,  # First 5 peaks from spec 0
+        np.arange(10, 15, dtype=np.float32) * 0.1  # Last 5 peaks from spec 2
+    ])
+    expected_extra_str_col = [f"peak_{i}" for i in list(range(5)) + list(range(10, 15))]
+    
+    assert np.array_equal(ms_data.peak_df["extra_peak_col"].values, expected_extra_peak_col)
+    assert ms_data.peak_df["extra_str_col"].tolist() == expected_extra_str_col
+    assert ms_data.spectrum_df["extra_spec_col"].tolist() == ["a", "c"]
+
+
+def test_remove_unused_peaks_with_subclass():
+    """Test remove_unused_peaks preserves class type and custom attributes"""
+    # Create a custom subclass instance
+    ms_data = CustomMSData()
+    
+    # Create spectrum_df with 3 spectra
+    ms_data.spectrum_df = pd.DataFrame({
+        "spec_idx": [0, 1, 2],
+        "rt": [1.0, 2.0, 3.0],
+        "ms_level": [1, 2, 2],
+        "peak_start_idx": [0, 5, 10],
+        "peak_stop_idx": [5, 10, 15]
+    })
+    
+    # Create peak_df with 15 peaks
+    ms_data.peak_df = pd.DataFrame({
+        "mz": np.arange(15, dtype=np.float32) + 100,
+        "intensity": np.arange(15, dtype=np.float32) * 1000
+    })
+    
+    # Filter out the middle spectrum (index 1)
+    ms_data.spectrum_df = ms_data.spectrum_df.loc[[0, 2]].reset_index(drop=True)
+    ms_data.spectrum_df["spec_idx"] = ms_data.spectrum_df.index
+    
+    # Call remove_unused_peaks with in_place=False to get a new instance
+    new_ms_data = ms_data.remove_unused_peaks(in_place=False)
+    
+    # Verify that the new instance is of the same class
+    assert isinstance(new_ms_data, CustomMSData)
+    assert type(new_ms_data) == type(ms_data)
+    
+    # Verify that custom attributes are preserved
+    assert hasattr(new_ms_data, 'custom_attribute')
+    assert hasattr(new_ms_data, 'another_attribute')
+    assert new_ms_data.custom_attribute == "custom_value"
+    assert new_ms_data.another_attribute == 42
+    
+    # Verify that the peak data is correct
+    assert len(new_ms_data.peak_df) == 10  # 5 peaks for spec 0 and 5 for spec 2
+    assert np.array_equal(new_ms_data.spectrum_df["peak_start_idx"].values, [0, 5])
+    assert np.array_equal(new_ms_data.spectrum_df["peak_stop_idx"].values, [5, 10])

--- a/tests/unit/test_remove_unused_peaks.py
+++ b/tests/unit/test_remove_unused_peaks.py
@@ -1,13 +1,13 @@
 import numpy as np
 import pandas as pd
-import pytest
+
 from alpharaw.ms_data_base import MSData_Base
 
 
 # Define a custom subclass for testing
 class CustomMSData(MSData_Base):
     """A custom subclass of MSData_Base for testing inheritance behavior"""
-    
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.custom_attribute = "custom_value"
@@ -18,28 +18,32 @@ def test_remove_unused_peaks_basic():
     """Test the basic functionality of remove_unused_peaks"""
     # Create a simple MSData_Base instance
     ms_data = MSData_Base()
-    
+
     # Create spectrum_df with 3 spectra
-    ms_data.spectrum_df = pd.DataFrame({
-        "spec_idx": [0, 1, 2],
-        "rt": [1.0, 2.0, 3.0],
-        "ms_level": [1, 2, 2],
-        "peak_start_idx": [0, 5, 10],
-        "peak_stop_idx": [5, 10, 15]
-    })
-    
+    ms_data.spectrum_df = pd.DataFrame(
+        {
+            "spec_idx": [0, 1, 2],
+            "rt": [1.0, 2.0, 3.0],
+            "ms_level": [1, 2, 2],
+            "peak_start_idx": [0, 5, 10],
+            "peak_stop_idx": [5, 10, 15],
+        }
+    )
+
     # Create peak_df with 15 peaks (5 per spectrum)
-    ms_data.peak_df = pd.DataFrame({
-        "mz": np.arange(15, dtype=np.float32) + 100,
-        "intensity": np.arange(15, dtype=np.float32) * 1000
-    })
-    
+    ms_data.peak_df = pd.DataFrame(
+        {
+            "mz": np.arange(15, dtype=np.float32) + 100,
+            "intensity": np.arange(15, dtype=np.float32) * 1000,
+        }
+    )
+
     # Test in-place modification
     result = ms_data.remove_unused_peaks(in_place=True)
-    
+
     # Verify that the method returns None for in-place modification
     assert result is None
-    
+
     # Verify that the peak indices remain the same since no spectra were removed
     assert len(ms_data.peak_df) == 15
     assert np.array_equal(ms_data.spectrum_df["peak_start_idx"].values, [0, 5, 10])
@@ -50,49 +54,57 @@ def test_remove_unused_peaks_with_filtering():
     """Test remove_unused_peaks when spectra have been removed"""
     # Create a simple MSData_Base instance
     ms_data = MSData_Base()
-    
+
     # Create spectrum_df with 3 spectra initially
-    ms_data.spectrum_df = pd.DataFrame({
-        "spec_idx": [0, 1, 2],
-        "rt": [1.0, 2.0, 3.0],
-        "ms_level": [1, 2, 2],
-        "peak_start_idx": [0, 5, 10],
-        "peak_stop_idx": [5, 10, 15]
-    })
-    
+    ms_data.spectrum_df = pd.DataFrame(
+        {
+            "spec_idx": [0, 1, 2],
+            "rt": [1.0, 2.0, 3.0],
+            "ms_level": [1, 2, 2],
+            "peak_start_idx": [0, 5, 10],
+            "peak_stop_idx": [5, 10, 15],
+        }
+    )
+
     # Create peak_df with 15 peaks (5 per spectrum)
-    ms_data.peak_df = pd.DataFrame({
-        "mz": np.arange(15, dtype=np.float32) + 100,
-        "intensity": np.arange(15, dtype=np.float32) * 1000
-    })
-    
+    ms_data.peak_df = pd.DataFrame(
+        {
+            "mz": np.arange(15, dtype=np.float32) + 100,
+            "intensity": np.arange(15, dtype=np.float32) * 1000,
+        }
+    )
+
     # Filter out the middle spectrum (index 1)
     ms_data.spectrum_df = ms_data.spectrum_df.loc[[0, 2]].reset_index(drop=True)
     ms_data.spectrum_df["spec_idx"] = ms_data.spectrum_df.index
-    
+
     # Now call remove_unused_peaks with in_place=False to get a new instance
     new_ms_data = ms_data.remove_unused_peaks(in_place=False)
-    
+
     # Verify that the original instance is unchanged
     assert len(ms_data.peak_df) == 15
     assert np.array_equal(ms_data.spectrum_df["peak_start_idx"].values, [0, 10])
     assert np.array_equal(ms_data.spectrum_df["peak_stop_idx"].values, [5, 15])
-    
+
     # Verify that the new instance has the correct peak data
     assert len(new_ms_data.peak_df) == 10  # 5 peaks for spec 0 and 5 for spec 2
     assert np.array_equal(new_ms_data.spectrum_df["peak_start_idx"].values, [0, 5])
     assert np.array_equal(new_ms_data.spectrum_df["peak_stop_idx"].values, [5, 10])
-    
+
     # Verify that the peak values are correct
-    expected_mzs = np.concatenate([
-        np.arange(5, dtype=np.float32) + 100,  # First 5 peaks from spec 0
-        np.arange(5, dtype=np.float32) + 110   # Last 5 peaks from spec 2
-    ])
-    expected_intensities = np.concatenate([
-        np.arange(5, dtype=np.float32) * 1000,  # First 5 peaks from spec 0
-        np.arange(10, 15, dtype=np.float32) * 1000  # Last 5 peaks from spec 2
-    ])
-    
+    expected_mzs = np.concatenate(
+        [
+            np.arange(5, dtype=np.float32) + 100,  # First 5 peaks from spec 0
+            np.arange(5, dtype=np.float32) + 110,  # Last 5 peaks from spec 2
+        ]
+    )
+    expected_intensities = np.concatenate(
+        [
+            np.arange(5, dtype=np.float32) * 1000,  # First 5 peaks from spec 0
+            np.arange(10, 15, dtype=np.float32) * 1000,  # Last 5 peaks from spec 2
+        ]
+    )
+
     assert np.array_equal(new_ms_data.peak_df["mz"].values, expected_mzs)
     assert np.array_equal(new_ms_data.peak_df["intensity"].values, expected_intensities)
 
@@ -101,50 +113,59 @@ def test_remove_unused_peaks_with_extra_columns():
     """Test remove_unused_peaks preserves additional columns in peak_df"""
     # Create a simple MSData_Base instance
     ms_data = MSData_Base()
-    
+
     # Create spectrum_df with 3 spectra
-    ms_data.spectrum_df = pd.DataFrame({
-        "spec_idx": [0, 1, 2],
-        "rt": [1.0, 2.0, 3.0],
-        "ms_level": [1, 2, 2],
-        "peak_start_idx": [0, 5, 10],
-        "peak_stop_idx": [5, 10, 15],
-        "extra_spec_col": ["a", "b", "c"]  # Extra column in spectrum_df
-    })
-    
+    ms_data.spectrum_df = pd.DataFrame(
+        {
+            "spec_idx": [0, 1, 2],
+            "rt": [1.0, 2.0, 3.0],
+            "ms_level": [1, 2, 2],
+            "peak_start_idx": [0, 5, 10],
+            "peak_stop_idx": [5, 10, 15],
+            "extra_spec_col": ["a", "b", "c"],  # Extra column in spectrum_df
+        }
+    )
+
     # Create peak_df with 15 peaks and an extra column
-    ms_data.peak_df = pd.DataFrame({
-        "mz": np.arange(15, dtype=np.float32) + 100,
-        "intensity": np.arange(15, dtype=np.float32) * 1000,
-        "extra_peak_col": np.arange(15, dtype=np.float32) * 0.1,  # Extra column in peak_df
-        "extra_str_col": [f"peak_{i}" for i in range(15)]  # String column
-    })
-    
+    ms_data.peak_df = pd.DataFrame(
+        {
+            "mz": np.arange(15, dtype=np.float32) + 100,
+            "intensity": np.arange(15, dtype=np.float32) * 1000,
+            "extra_peak_col": np.arange(15, dtype=np.float32)
+            * 0.1,  # Extra column in peak_df
+            "extra_str_col": [f"peak_{i}" for i in range(15)],  # String column
+        }
+    )
+
     # Filter out the middle spectrum (index 1)
     ms_data.spectrum_df = ms_data.spectrum_df.loc[[0, 2]].reset_index(drop=True)
     ms_data.spectrum_df["spec_idx"] = ms_data.spectrum_df.index
-    
+
     # Call remove_unused_peaks with in_place=True
     ms_data.remove_unused_peaks(in_place=True)
-    
+
     # Verify that the peak data is correct
     assert len(ms_data.peak_df) == 10  # 5 peaks for spec 0 and 5 for spec 2
     assert np.array_equal(ms_data.spectrum_df["peak_start_idx"].values, [0, 5])
     assert np.array_equal(ms_data.spectrum_df["peak_stop_idx"].values, [5, 10])
-    
+
     # Verify that extra columns are preserved
     assert "extra_peak_col" in ms_data.peak_df.columns
     assert "extra_str_col" in ms_data.peak_df.columns
     assert "extra_spec_col" in ms_data.spectrum_df.columns
-    
+
     # Verify that the extra column values are correctly mapped
-    expected_extra_peak_col = np.concatenate([
-        np.arange(5, dtype=np.float32) * 0.1,  # First 5 peaks from spec 0
-        np.arange(10, 15, dtype=np.float32) * 0.1  # Last 5 peaks from spec 2
-    ])
+    expected_extra_peak_col = np.concatenate(
+        [
+            np.arange(5, dtype=np.float32) * 0.1,  # First 5 peaks from spec 0
+            np.arange(10, 15, dtype=np.float32) * 0.1,  # Last 5 peaks from spec 2
+        ]
+    )
     expected_extra_str_col = [f"peak_{i}" for i in list(range(5)) + list(range(10, 15))]
-    
-    assert np.array_equal(ms_data.peak_df["extra_peak_col"].values, expected_extra_peak_col)
+
+    assert np.array_equal(
+        ms_data.peak_df["extra_peak_col"].values, expected_extra_peak_col
+    )
     assert ms_data.peak_df["extra_str_col"].tolist() == expected_extra_str_col
     assert ms_data.spectrum_df["extra_spec_col"].tolist() == ["a", "c"]
 
@@ -153,39 +174,43 @@ def test_remove_unused_peaks_with_subclass():
     """Test remove_unused_peaks preserves class type and custom attributes"""
     # Create a custom subclass instance
     ms_data = CustomMSData()
-    
+
     # Create spectrum_df with 3 spectra
-    ms_data.spectrum_df = pd.DataFrame({
-        "spec_idx": [0, 1, 2],
-        "rt": [1.0, 2.0, 3.0],
-        "ms_level": [1, 2, 2],
-        "peak_start_idx": [0, 5, 10],
-        "peak_stop_idx": [5, 10, 15]
-    })
-    
+    ms_data.spectrum_df = pd.DataFrame(
+        {
+            "spec_idx": [0, 1, 2],
+            "rt": [1.0, 2.0, 3.0],
+            "ms_level": [1, 2, 2],
+            "peak_start_idx": [0, 5, 10],
+            "peak_stop_idx": [5, 10, 15],
+        }
+    )
+
     # Create peak_df with 15 peaks
-    ms_data.peak_df = pd.DataFrame({
-        "mz": np.arange(15, dtype=np.float32) + 100,
-        "intensity": np.arange(15, dtype=np.float32) * 1000
-    })
-    
+    ms_data.peak_df = pd.DataFrame(
+        {
+            "mz": np.arange(15, dtype=np.float32) + 100,
+            "intensity": np.arange(15, dtype=np.float32) * 1000,
+        }
+    )
+
     # Filter out the middle spectrum (index 1)
     ms_data.spectrum_df = ms_data.spectrum_df.loc[[0, 2]].reset_index(drop=True)
     ms_data.spectrum_df["spec_idx"] = ms_data.spectrum_df.index
-    
+
     # Call remove_unused_peaks with in_place=False to get a new instance
     new_ms_data = ms_data.remove_unused_peaks(in_place=False)
-    
+
     # Verify that the new instance is of the same class
     assert isinstance(new_ms_data, CustomMSData)
     assert type(new_ms_data) == type(ms_data)
-    
+
     # Verify that custom attributes are preserved
-    assert hasattr(new_ms_data, 'custom_attribute')
-    assert hasattr(new_ms_data, 'another_attribute')
+    assert hasattr(new_ms_data, "custom_attribute")
+    assert hasattr(new_ms_data, "another_attribute")
     assert new_ms_data.custom_attribute == "custom_value"
     assert new_ms_data.another_attribute == 42
-    
+
     # Verify that the peak data is correct
     assert len(new_ms_data.peak_df) == 10  # 5 peaks for spec 0 and 5 for spec 2
     assert np.array_equal(new_ms_data.spectrum_df["peak_start_idx"].values, [0, 5])


### PR DESCRIPTION
 Add remove_unused_peaks method to MSData_Base for efficient peak dataframe cleanup after spectrum filtering. Includes a numba-accelerated mask generator for high performance and supports both in-place and copy operations with full class  inheritance preservation.
 
This PR was 1.87USD
