### PR TITLE
Decouple dotnet

### DIFF
--- a/alpharaw/raw_access/clr_utils.py
+++ b/alpharaw/raw_access/clr_utils.py
@@ -12,8 +12,6 @@ try:
     import ctypes
 
     from System.Runtime.InteropServices import GCHandle, GCHandleType
-
-    HAS_DOTNET = True
 except Exception:
     # allows to use the rest of the code without clr
     warnings.warn("Dotnet-based dependencies could not be loaded.")

--- a/alpharaw/raw_access/clr_utils.py
+++ b/alpharaw/raw_access/clr_utils.py
@@ -12,14 +12,11 @@ try:
     import ctypes
 
     from System.Runtime.InteropServices import GCHandle, GCHandleType
+
+    HAS_DOTNET = True
 except Exception:
     # allows to use the rest of the code without clr
-    import traceback
-
-    traceback.print_exc()
-    warnings.warn(
-        "Dotnet-based dependencies not installed. Do you have pythonnet and mono (Mac/Linux) installed?"
-    )
+    warnings.warn("Dotnet-based dependencies could not be loaded.")
 
 # from System.Runtime.InteropServices import Marshal
 # from System import IntPtr, Int64

--- a/alpharaw/raw_access/pysciexwifffilereader.py
+++ b/alpharaw/raw_access/pysciexwifffilereader.py
@@ -51,7 +51,9 @@ class WillFileReader:
     def __init__(self, filename: str):
         if not HAS_DOTNET:
             raise ValueError(
-                "Dotnet-based dependencies are required for reading Sciex files. Do you have pythonnet and mono (Mac/Linux) installed?"
+                "Dotnet-based dependencies are required for reading Sciex files. "
+                "Do you have pythonnet and/or mono installed? "
+                "See the Readme for details."
             )
 
         self._wiffDataProvider = AnalystWiffDataProvider()

--- a/alpharaw/raw_access/pysciexwifffilereader.py
+++ b/alpharaw/raw_access/pysciexwifffilereader.py
@@ -51,7 +51,7 @@ class WillFileReader:
     def __init__(self, filename: str):
         if not HAS_DOTNET:
             raise ValueError(
-                "Dotnet-based dependencies are not available. Do you have pythonnet and mono (Mac/Linux) installed?"
+                "Dotnet-based dependencies are required for reading Sciex files. Do you have pythonnet and mono (Mac/Linux) installed?"
             )
 
         self._wiffDataProvider = AnalystWiffDataProvider()

--- a/alpharaw/raw_access/pysciexwifffilereader.py
+++ b/alpharaw/raw_access/pysciexwifffilereader.py
@@ -1,13 +1,15 @@
 # ruff: noqa: E402  #Module level import not at top of file
 import os
+import warnings
 
-# require pythonnet, pip install pythonnet on Windows
-import clr
 import numpy as np
 
 from alpharaw.utils.centroiding import naive_centroid
 
 try:
+    # require pythonnet, pip install pythonnet on Windows
+    import clr
+
     clr.AddReference("System")
 
     import System  # noqa: F401
@@ -35,18 +37,23 @@ try:
         AnalystWiffDataProvider,
     )
     from WiffOps4Python import WiffOps as DotNetWiffOps
+
+    HAS_DOTNET = True
 except Exception:
     # allows to use the rest of the code without clr
-    import traceback
-
-    traceback.print_exc()
-    print(
-        "Warning: could not import dotnet-based dependencies. Do you have pythonnet and mono (Mac/Linux) installed?"
+    warnings.warn(
+        "Dotnet-based dependencies could not be loaded. Sciex support is disabled."
     )
+    HAS_DOTNET = False
 
 
 class WillFileReader:
     def __init__(self, filename: str):
+        if not HAS_DOTNET:
+            raise ValueError(
+                "Dotnet-based dependencies are not available. Do you have pythonnet and mono (Mac/Linux) installed?"
+            )
+
         self._wiffDataProvider = AnalystWiffDataProvider()
         self._wiff_file = AnalystDataProviderFactory.CreateBatch(
             filename, self._wiffDataProvider

--- a/alpharaw/raw_access/pythermorawfilereader.py
+++ b/alpharaw/raw_access/pythermorawfilereader.py
@@ -28,14 +28,14 @@ try:
     )
     import ThermoFisher
     from ThermoFisher.CommonCore.Data.Interfaces import IScanEvent, IScanEventBase
+
+    HAS_DOTNET = True
 except Exception:
     # allows to use the rest of the code without clr
-    import traceback
-
-    traceback.print_exc()
     warnings.warn(
-        "Dotnet-based dependencies not installed. Do you have pythonnet and mono (Mac/Linux) installed?"
+        "Dotnet-based dependencies could not be loaded. Thermo support is disabled."
     )
+    HAS_DOTNET = False
 
 
 """C# code to read Raw data
@@ -189,6 +189,11 @@ class RawFileReader:
     }
 
     def __init__(self, filename, **kwargs):
+        if not HAS_DOTNET:
+            raise ValueError(
+                "Dotnet-based dependencies are required for reading Thermo files. Do you have pythonnet and mono (Mac/Linux) installed?"
+            )
+
         self.filename = os.path.abspath(filename)
         self.filename = os.path.normpath(self.filename)
 

--- a/alpharaw/raw_access/pythermorawfilereader.py
+++ b/alpharaw/raw_access/pythermorawfilereader.py
@@ -191,7 +191,9 @@ class RawFileReader:
     def __init__(self, filename, **kwargs):
         if not HAS_DOTNET:
             raise ValueError(
-                "Dotnet-based dependencies are required for reading Thermo files. Do you have pythonnet and mono (Mac/Linux) installed?"
+                "Dotnet-based dependencies are required for reading Thermo files. "
+                "Do you have pythonnet and/or mono installed? "
+                "See the Readme for details."
             )
 
         self.filename = os.path.abspath(filename)


### PR DESCRIPTION
This allows to run alphadia without mono for bruker files.


This is how it looks for Thermo files:
![image](https://github.com/user-attachments/assets/dfbd5d89-95b6-4734-9dda-42aed65231de)
