### PR TITLE
Reading out evosep LC meta data

### DIFF
--- a/alpharaw/raw_access/pythermorawfilereader.py
+++ b/alpharaw/raw_access/pythermorawfilereader.py
@@ -671,10 +671,16 @@ class RawFileReader:
         Parameters
         ----------
         parameter : str
-            The parameter ID to use for data retrieval, defined in evoSepDict. E.g. "PumpHP_pressure" for the HP pressure pump.
+            The parameter ID to use for data retrieval, defined in evosep_observable_to_device_mapping.
+            E.g. "PumpHP_pressure" for the HP pressure pump.
         """
 
-        device = RawFileReader.evosep_observable_to_device_mapping[parameter]
+        try:
+            device = RawFileReader.evosep_observable_to_device_mapping[parameter]
+        except KeyError as e:
+            raise KeyError(
+                f"Key '{parameter}' not found. Available keys: {RawFileReader.evosep_observable_to_device_mapping.keys()}"
+            ) from e
 
         self.source.SelectInstrument(Device.Analog, device)
 
@@ -690,7 +696,7 @@ class RawFileReader:
             stats1 = self.source.GetScanStatsForScanNumber(i)
             data.append(
                 (i, rt, stats1.TIC)
-            )  # TIC refers tot the actual value e.g. bar in the case of the HP pressure pump
+            )  # TIC refers to the actual value e.g. bar in the case of the HP pressure pump
 
         evosep_data = {
             "IDX": [row[0] for row in data],


### PR DESCRIPTION
In order to extract evosep LC meta data from thermo raw files, a function was implemented to do so (GetEvoSepData).

A dictionary containing the identifiers of the lc data was added to the top of the class as evosepdict which can be passed as an argument to GetEvoSepData.

Currently, this only works for thermo data, as bruker and sciex instruments do not track any LC data in their raw files.