### PR TITLE
Fix CLI parse command to save HDF output

### DIFF
--- a/alpharaw/cli.py
+++ b/alpharaw/cli.py
@@ -63,3 +63,4 @@ def _parse(raw_type: str, raw: list):
                 print(f"{raw_file} does not exist")
                 continue
             reader.import_raw(raw_file)
+            reader.save_hdf(raw_file + ".hdf")


### PR DESCRIPTION
## Summary
This fixes the `alpharaw parse` CLI flow so that it writes the expected HDF output file after importing the input file.

## What changed
- explicitly save HDF output in the CLI parse command

## Why
The reader import path works, but the CLI command did not appear to produce an output file because it only called `import_raw(...)` without saving the result.

## Validation
Tested with:
- `./nbs_tests/test_data/small.pwiz.1.1.mzML`

Confirmed that:
- manual import + save works
- CLI now produces HDF output
- 
#### To-do list (outside contributers only)
- [x] I have read and agree to the [MannLabs Contributor License Agreement](https://github.com/MannLabs/.github/blob/main/CLA.md)